### PR TITLE
Add Widgets extension

### DIFF
--- a/group_vars/all/default_extensions
+++ b/group_vars/all/default_extensions
@@ -255,3 +255,9 @@ DEFAULT_EXTENSIONS:
   - name: "Piwik"
     url: "https://github.com/DaSchTour/piwik-mediawiki-extension.git"
     version: master
+
+  - name: "Widgets"
+    url: "{{ MW_EXTENSIONS_GIT_URL_ROOT }}Widgets.git"
+    enable: global
+    version: master
+    writable_dirs: compiled_templates

--- a/roles/install_extensions/tasks/main.yml
+++ b/roles/install_extensions/tasks/main.yml
@@ -82,3 +82,7 @@
     line="\n{{ item.config }}"
   with_items: "{{ EXTENSIONS }}"
   when: item.enable is defined and item.enable == "local" and item.config is defined
+
+- name: make directory writable by web server
+  shell: for dir in {{ item.writable_dirs }}; do mkdir {{ MW_CODE_RELEASE_DIRECTORY }}/{{ item.name }}/$dir; chmod a+rw {{ MW_CODE_RELEASE_DIRECTORY }}/{{ item.name }}/$dir; done
+  when: item.writable_dirs is defined


### PR DESCRIPTION
This extension will allow to easily embed and configure a google calendar
widget.

See https://www.mediawiki.org/wiki/Extension:Widgets#Configuration

Note that since the extension requires that the "compiled_templates" to
exist and be writable by the web server, the "install_extensions" role
has been updated to check for the "writable_dirs" attribute.
